### PR TITLE
fix: add missing fields to TransactionResponse

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -242,18 +242,8 @@ export interface PageDetails {
 export interface TransactionResponse {
     id: string;
     assetId: string;
-    source: {
-        id: string;
-        type: PeerType;
-        name?: string;
-        subType?: string;
-    };
-    destination: {
-        id: string;
-        type: PeerType;
-        name?: string;
-        subType?: string;
-    };
+    source: TransferPeerPathResponse;
+    destination: TransferPeerPathResponse;
     amount: number;
     /**
      * @deprecated Replaced by "networkFee"
@@ -280,17 +270,54 @@ export interface TransactionResponse {
     requestedAmount: number;
     serviceFee?: number;
     feeCurrency: string;
-    amlScreeningResult?: {
-        provider?: string;
-        payload: any;
-        screeningStatus: string;
-        bypassReason: string;
-        timestamp: number;
-    };
+    amlScreeningResult?: AmlScreeningResult;
+    customerRefId?: string;
+    amountInfo?: AmountInfo;
+    feeInfo?: FeeInfo;
     signedMessages?: SignedMessageResponse[];
+    extraParameters?: any;
     externalTxId?: string;
+    destinations?: TransactionResponseDestination[];
     blockInfo?: BlockInfo;
     authorizationInfo?: AuthorizationInfo;
+    index?: number;
+}
+
+export interface AmountInfo {
+    amount?: string;
+    requestedAmount?: string;
+    netAmount?: string;
+    amountUSD?: string;
+}
+
+export interface FeeInfo {
+    networkFee?: string;
+    serviceFee?: string;
+}
+
+export interface TransactionResponseDestination {
+    amount?: string;
+    amountUSD?: string;
+    amlScreeningResult?: AmlScreeningResult;
+    destination?: TransferPeerPathResponse;
+    authorizationInfo?: AuthorizationInfo;
+}
+
+export interface AmlScreeningResult {
+    provider?: string;
+    payload: any;
+    screeningStatus: string;
+    bypassReason: string;
+    timestamp: number;
+}
+
+export interface TransferPeerPathResponse {
+    id: string;
+    type: PeerType;
+    name?: string;
+    subType?: string;
+    virtualType?: VirtualType;
+    virtualId?: string;
 }
 
 export interface AuthorizationInfo {


### PR DESCRIPTION
## Pull Request Description

Add missing fields to `TransactionResponse` interfaces
Fixes [(#68)](https://github.com/fireblocks/fireblocks-sdk-js/issues/68)

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
