### PR TITLE
Add gasPrice to response when it exists

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -293,6 +293,7 @@ export interface AmountInfo {
 export interface FeeInfo {
     networkFee?: string;
     serviceFee?: string;
+    gasPrice?: string;
 }
 
 export interface TransactionResponseDestination {


### PR DESCRIPTION
## Pull Request Description

Added gasPrice in response for transactions, when applicable.

Fixes (link to the issue here)

## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested using the api test client, tried getting single transaction and see that data is returned

- [ x] Locally tested against Fireblocks API

