### PR TITLE
deprecate getVaultAccounts method

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -87,6 +87,7 @@ export class FireblocksSDK {
     }
 
     /**
+     * @deprecated this method is deprecated and will be removed in the future. Please use getVaultAccountsWithPageInfo instead.
      * Gets all vault accounts for your tenant
      */
     public async getVaultAccounts(filter?: VaultAccountsFilter): Promise<VaultAccountResponse[]> {


### PR DESCRIPTION
## Pull Request Description

Deprecation of getVaultAccounts method as the endpoint `/vault/accounts` is deprecated and will be removed in future release.

## Type of change

Please delete options that are not relevant.

- [X] Deprecation of a method