### PR TITLE
fix: add response interceptor to cast axios error to FireBlocksError

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,14 +1,25 @@
 import { IAuthProvider } from "./iauth-provider";
 import { RequestOptions } from "./types";
 import axios, { AxiosInstance } from "axios";
+import FireBlocksError from "./fireblocks-error";
 
 export class ApiClient {
     private axiosInstance: AxiosInstance;
 
-    constructor(private authProvider: IAuthProvider, private apiBaseUrl: string, private options: {timeoutInMs?: number}) {
+    constructor(private authProvider: IAuthProvider, private apiBaseUrl: string, private options: { timeoutInMs?: number }) {
         this.axiosInstance = axios.create({
             baseURL: this.apiBaseUrl
         });
+        this.axiosInstance.interceptors.response.use(
+            (response) => response,
+            (error) => {
+                if (error?.response?.data) {
+                    throw new FireBlocksError(error.response.data.message, error.response.data.code, error.response.status);
+                } else {
+                    throw new Error(error.toJSON());
+                }
+            },
+        );
     }
 
     public async issueGetRequest(path: string, pageMode: boolean = false) {

--- a/src/fireblocks-error.ts
+++ b/src/fireblocks-error.ts
@@ -1,0 +1,12 @@
+export default class FireBlocksError extends Error {
+    private statusCode: number;
+    private fireblocksCode: number;
+
+    constructor(message: string, fireblocksCode: number, statusCode: number,) {
+        super(message);
+        this.name = "FireBlocksError";
+        this.message = message;
+        this.statusCode = statusCode;
+        this.fireblocksCode = fireblocksCode;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

In my experience of using this library i noticed it doest give enough information about the errors for example 400 errors and we couldn't track the issue and had to create a fork of this library and return the errors the error to client as FireblocksError class

Fixes [(Return fireblocks error message on 400 error)](https://github.com/fireblocks/fireblocks-sdk-js/issues/103)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

i have tested it on staging and prod of Fireblocks API
You can try to create a vault asset with asset_id = `DAI_TEST` with will throw an error with status code 400

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
