### PR TITLE
add proxy support for axios instance

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,13 +1,14 @@
 import { IAuthProvider } from "./iauth-provider";
 import { RequestOptions } from "./types";
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosInstance, AxiosProxyConfig } from 'axios';
 
 export class ApiClient {
     private axiosInstance: AxiosInstance;
 
-    constructor(private authProvider: IAuthProvider, private apiBaseUrl: string, private options: {timeoutInMs?: number}) {
+    constructor(private authProvider: IAuthProvider, private apiBaseUrl: string, private options: {timeoutInMs?: number, proxyConf?: AxiosProxyConfig | false}) {
         this.axiosInstance = axios.create({
-            baseURL: this.apiBaseUrl
+            baseURL: this.apiBaseUrl,
+            proxy: this.options.proxyConf,
         });
     }
 

--- a/src/api-token-provider.ts
+++ b/src/api-token-provider.ts
@@ -1,6 +1,6 @@
 import { IAuthProvider } from "./iauth-provider";
-import jwt from "jsonwebtoken";
-import crypto from "crypto";
+import * as jwt from "jsonwebtoken";
+import * as crypto from "crypto";
 import { v4 as uuid } from "uuid";
 
 export class ApiTokenProvider implements IAuthProvider {

--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -51,11 +51,13 @@ import {
     TimePeriod,
     AuditsResponse,
 } from "./types";
+import { AxiosProxyConfig } from 'axios';
 
 export * from "./types";
 
 export interface SDKOptions {
     timeoutInMs: number;
+    proxy: AxiosProxyConfig | false;
 }
 
 export class FireblocksSDK {
@@ -72,13 +74,13 @@ export class FireblocksSDK {
      * @param sdkOptions
      */
     constructor(privateKey: string, apiKey: string, apiBaseUrl: string = "https://api.fireblocks.io", authProvider: IAuthProvider = undefined, sdkOptions?: SDKOptions) {
-        this.authProvider = authProvider ?? new ApiTokenProvider(privateKey, apiKey);
+        this.authProvider = !!authProvider ? authProvider : new ApiTokenProvider(privateKey, apiKey);
 
-        if (apiBaseUrl) {
+        if (!!apiBaseUrl) {
             this.apiBaseUrl = apiBaseUrl;
         }
 
-        this.apiClient = new ApiClient(this.authProvider, this.apiBaseUrl, {timeoutInMs: sdkOptions?.timeoutInMs});
+        this.apiClient = new ApiClient(this.authProvider, this.apiBaseUrl, {timeoutInMs: sdkOptions?.timeoutInMs, proxyConf: sdkOptions?.proxy});
     }
 
     /**


### PR DESCRIPTION
## Pull Request Description

[[Feature Request]support http proxy #115](https://github.com/fireblocks/fireblocks-sdk-js/issues/115)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Set up a proxy server for proxying http traffic to fireblocks api which is recommended by using `squid`, and pass `SDKOptions` parameter when create a new `FireblocksSDK`, for example

```typescript
    let proxyConf: AxiosProxyConfig = {
      host: process.env.PROXY_HOST,
      port: parseInt(process.env.PROXY_PORT),
      protocol: process.env.PROXY_PROTOCOL,
    };

    this.fireblocksClient = new FireblocksSDK(this.apiSecret, this.apiKey, this.apiBaseUrl, undefined, {
      timeoutInMs: 120000,
      proxy: proxyConf,
    });
```

- [x] Locally tested against Fireblocks API

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
