### PR TITLE
feat: add support for axios response interceptor, remove deprecated methods

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -79,5 +79,17 @@ new FireblocksSDK(privateKey, userId, serverAddress, undefined, {
 });
 ```
 
+#### Error Handling
+The SDK throws `AxiosError` upon http errors for API requests.
+
+You can read more about axios error handling [here](https://axios-http.com/docs/handling_errors).
+
+You can get more data on the Fireblocks error using the following fields:
+
+- `error.response.data.code`: The Fireblocks error code, should be provided on support tickets
+- `error.response.data.message`: Explanation of the Fireblocks error
+- `error.response.headers['x-request-id']`: The request ID correlated to the API request, should be provided on support tickets / Github issues
+
+
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Using v4 you can now use the response header `x-request-id` which correlates the
 
 You can provide the value of this header in case you have support tickets related to an API operation, or a Github issue.
 
+### Removed deprecated methods
+- `getVaultAccounts` method was removed. It is replaced by the `getVaultAccountsWithPageInfo` method
+- `getVaultAccount` method was removed. It is replaced by the `getVaultAccountById` method
+- `getExchangeAccount` was removed in favour of `getExchangeAccountById`
+
 ## Usage
 #### Before You Begin
 Make sure you have the credentials for Fireblocks API Services. Otherwise, please contact Fireblocks support for further instructions on how to obtain your API credentials.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can provide the value of this header in case you have support tickets relate
 Make sure you have the credentials for Fireblocks API Services. Otherwise, please contact Fireblocks support for further instructions on how to obtain your API credentials.
 
 #### Requirements
-- [node.js](https://nodejs.org) v6.3.1 or newer
+- [node.js](https://nodejs.org) v12 or newer
 
 #### Installation
 `npm install fireblocks-sdk --save`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@
 This repository contains the official Javascript & Typescript SDK for Fireblocks API.
 For the complete API reference, go to [API reference](https://docs.fireblocks.com/api/swagger-ui/).
 
+## V4 Migration
+In v4 we changed all the sdk response types to return the `APIResponse` object, which is defined as:
+```ts
+export interface APIResponse<T> {
+    data: T; // http response body
+    headers?: AxiosResponseHeaders; // http response headers
+}
+```
+
+This means that if you previously fetched data in the following way:
+```ts
+const exchangeAccounts: ExchangeResponse = await sdk.getExchangeAccount(exchangeAccountId);
+```
+
+It should be transformed to:
+```ts
+const {data: exchangeAccounts, responseHeaders: headers} = (await sdk.getExchangeAccount(exchangeAccountId));
+```
+
+### `X-REQUEST-ID` Response Header
+Using v4 you can now use the response header `x-request-id` which correlates the request to the Fireblocks operation.
+
+You can provide the value of this header in case you have support tickets related to an API operation, or a Github issue.
+
 ## Usage
 #### Before You Begin
 Make sure you have the credentials for Fireblocks API Services. Otherwise, please contact Fireblocks support for further instructions on how to obtain your API credentials.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ In v4 we changed all the sdk response types to return the `APIResponse` object, 
 ```ts
 export interface APIResponse<T> {
     data: T; // http response body
+    status?: number; // http status code
     headers?: AxiosResponseHeaders; // http response headers
 }
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const exchangeAccounts: ExchangeResponse = await sdk.getExchangeAccount(exchange
 
 It should be transformed to:
 ```ts
-const {data: exchangeAccounts, responseHeaders: headers} = (await sdk.getExchangeAccount(exchangeAccountId));
+const {data: exchangeAccounts, headers} = (await sdk.getExchangeAccount(exchangeAccountId));
 ```
 
 ### `X-REQUEST-ID` Response Header

--- a/README.md
+++ b/README.md
@@ -6,45 +6,7 @@ This repository contains the official Javascript & Typescript SDK for Fireblocks
 For the complete API reference, go to [API reference](https://docs.fireblocks.com/api/swagger-ui/).
 
 ## V4 Migration
-### `X-REQUEST-ID` Response Header
-Using v4 you can now use the response header `x-request-id` which correlates the request to the Fireblocks operation.
-
-You can provide the value of this header in case you have support tickets related to an API operation, or a Github issue.
-
-In case of API request failures the SDK throws an AxiosError that contains the following fields:
-```ts
-      error.response.data; // the error body
-      error.response.status; // the error status code
-      error.response.headers; // the error headers
-```
-
-- You can get the request-id by using the `error.response.headers['x-request-id']` field
-- Another way of getting the request-id for successful operations as well, will be to provide an axios response interceptor 
-
-For example, you can provide the sdk options with an axios response interceptor:
-```ts
-new FireblocksSDK(privateKey, userId, serverAddress, undefined, {
-        customAxiosOptions: {
-            interceptors: {
-                response: {
-                    onFulfilled: (response) => {
-                        console.log(`Request ID: ${response.headers["x-request-id"]}`);
-                        return response;
-                    },
-                    onRejected: (error) => {
-                        console.log(`Request ID: ${error.response.headers["x-request-id"]}`);
-                        throw error;
-                    }
-                }
-            }
-        }
-    });
-```
-
-### Removed deprecated methods
-- `getVaultAccounts` method was removed. It is replaced by the `getVaultAccountsWithPageInfo` method
-- `getVaultAccount` method was removed. It is replaced by the `getVaultAccountById` method
-- `getExchangeAccount` was removed in favour of `getExchangeAccountById`
+Please read the [following](./docs/V4-MIGRATION.md) guide for migration
 
 ## Usage
 #### Before You Begin
@@ -95,3 +57,27 @@ interface SDKOptions {
     userAgent?: string;
 }
 ```
+
+#### Axios Interceptor
+You can provide the sdk options with an [axios response interceptor](https://axios-http.com/docs/interceptors):
+```ts
+new FireblocksSDK(privateKey, userId, serverAddress, undefined, {
+    customAxiosOptions: {
+        interceptors: {
+            response: {
+                onFulfilled: (response) => {
+                    console.log(`Request ID: ${response.headers["x-request-id"]}`);
+                    return response;
+                },
+                onRejected: (error) => {
+                    console.log(`Request ID: ${error.response.headers["x-request-id"]}`);
+                    throw error;
+                }
+            }
+        }
+    }
+});
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -6,29 +6,40 @@ This repository contains the official Javascript & Typescript SDK for Fireblocks
 For the complete API reference, go to [API reference](https://docs.fireblocks.com/api/swagger-ui/).
 
 ## V4 Migration
-In v4 we changed all the sdk response types to return the `APIResponse` object, which is defined as:
-```ts
-export interface APIResponse<T> {
-    data: T; // http response body
-    status?: number; // http status code
-    headers?: AxiosResponseHeaders; // http response headers
-}
-```
-
-This means that if you previously fetched data in the following way:
-```ts
-const exchangeAccounts: ExchangeResponse = await sdk.getExchangeAccount(exchangeAccountId);
-```
-
-It should be transformed to:
-```ts
-const {data: exchangeAccounts, headers} = (await sdk.getExchangeAccount(exchangeAccountId));
-```
-
 ### `X-REQUEST-ID` Response Header
 Using v4 you can now use the response header `x-request-id` which correlates the request to the Fireblocks operation.
 
 You can provide the value of this header in case you have support tickets related to an API operation, or a Github issue.
+
+In case of API request failures the SDK throws an AxiosError that contains the following fields:
+```ts
+      error.response.data; // the error body
+      error.response.status; // the error status code
+      error.response.headers; // the error headers
+```
+
+- You can get the request-id by using the `error.response.headers['x-request-id']` field
+- Another way of getting the request-id for successful operations as well, will be to provide an axios response interceptor 
+
+For example, you can provide the sdk options with an axios response interceptor:
+```ts
+new FireblocksSDK(privateKey, userId, serverAddress, undefined, {
+        customAxiosOptions: {
+            interceptors: {
+                response: {
+                    onFulfilled: (response) => {
+                        console.log(`Request ID: ${response.headers["x-request-id"]}`);
+                        return response;
+                    },
+                    onRejected: (error) => {
+                        console.log(`Request ID: ${error.response.headers["x-request-id"]}`);
+                        throw error;
+                    }
+                }
+            }
+        }
+    });
+```
 
 ### Removed deprecated methods
 - `getVaultAccounts` method was removed. It is replaced by the `getVaultAccountsWithPageInfo` method

--- a/docs/V4-MIGRATION.md
+++ b/docs/V4-MIGRATION.md
@@ -1,0 +1,40 @@
+## V4 Migration
+### `X-REQUEST-ID` Response Header
+Using v4 you can now use the response header `x-request-id` which correlates the request to the Fireblocks operation.
+
+You can provide the value of this header in case you have support tickets related to an API operation, or a Github issue.
+
+In case of API request failures the SDK throws an AxiosError that contains the following fields:
+```ts
+      error.response.data; // the error body
+      error.response.status; // the error status code
+      error.response.headers; // the error headers
+```
+
+- You can get the request-id by using the `error.response.headers['x-request-id']` field
+- Another way of getting the request-id for successful operations as well, will be to provide an axios response interceptor
+
+For example, you can provide the sdk options with an axios response interceptor:
+```ts
+new FireblocksSDK(privateKey, userId, serverAddress, undefined, {
+        customAxiosOptions: {
+            interceptors: {
+                response: {
+                    onFulfilled: (response) => {
+                        console.log(`Request ID: ${response.headers["x-request-id"]}`);
+                        return response;
+                    },
+                    onRejected: (error) => {
+                        console.log(`Request ID: ${error.response.headers["x-request-id"]}`);
+                        throw error;
+                    }
+                }
+            }
+        }
+    });
+```
+
+### Removed deprecated methods
+- `getVaultAccounts` method was removed. It is replaced by the `getVaultAccountsWithPageInfo` method
+- `getVaultAccount` method was removed. It is replaced by the `getVaultAccountById` method
+- `getExchangeAccount` was removed in favour of `getExchangeAccountById`

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -56,7 +56,8 @@ export class ApiClient {
         });
         return {
             data: res.data,
-            headers: res.headers
+            headers: res.headers,
+            status: res.status,
         };
     }
 
@@ -70,7 +71,8 @@ export class ApiClient {
         const response = await this.axiosInstance.post(path, body, {headers});
         return {
             data: response.data,
-            headers: response.headers
+            headers: response.headers,
+            status: response.status,
         };
     }
 
@@ -82,6 +84,7 @@ export class ApiClient {
         return {
             data: res.data,
             headers: res.headers,
+            status: res.status,
         };
     }
 
@@ -92,7 +95,8 @@ export class ApiClient {
         }));
         return {
             data: res.data,
-            headers: res.headers
+            headers: res.headers,
+            status: res.status,
         };
     }
 
@@ -103,7 +107,8 @@ export class ApiClient {
         }));
         return {
             data: res.data,
-            headers: res.headers
+            headers: res.headers,
+            status: res.status,
         };
     }
 }

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import platform from "platform";
 import { IAuthProvider } from "./iauth-provider";
-import { APIResponse, RequestOptions, TransactionPageResponse } from "./types";
+import { RequestOptions, TransactionPageResponse } from "./types";
 import { SDKOptions } from "./fireblocks-sdk";
 import axios, { AxiosInstance } from "axios";
 import { version as SDK_VERSION } from "../package.json";
@@ -19,6 +19,10 @@ export class ApiClient {
                 "User-Agent": this.getUserAgent()
             }
         });
+
+        if (options.customAxiosOptions?.interceptors?.response) {
+            this.axiosInstance.interceptors.response.use(options.customAxiosOptions.interceptors.response.onFulfilled, options.customAxiosOptions.interceptors.response.onRejected);
+        }
     }
 
     private getUserAgent(): string {
@@ -32,83 +36,60 @@ export class ApiClient {
         return userAgent;
     }
 
-    public async issueGetRequestForTransactionPages(path: string): Promise<APIResponse<TransactionPageResponse>> {
+    public async issueGetRequestForTransactionPages(path: string): Promise<TransactionPageResponse> {
         const token = this.authProvider.signJwt(path);
         const res = await this.axiosInstance.get(path, {
             headers: {"Authorization": `Bearer ${token}`}
         });
         return {
-            data: {
-                transactions: res.data,
-                pageDetails: {
-                    prevPage: res.headers["prev-page"] ? res.headers["prev-page"].toString() : "",
-                    nextPage: res.headers["next-page"] ? res.headers["next-page"].toString() : "",
-                }
-            },
-            headers: res.headers
+            transactions: res.data,
+            pageDetails: {
+                prevPage: res.headers["prev-page"] ? res.headers["prev-page"].toString() : "",
+                nextPage: res.headers["next-page"] ? res.headers["next-page"].toString() : "",
+            }
         };
     }
 
-    public async issueGetRequest<T>(path: string): Promise<APIResponse<T>> {
+    public async issueGetRequest<T>(path: string): Promise<T> {
         const token = this.authProvider.signJwt(path);
         const res = await this.axiosInstance.get(path, {
             headers: {"Authorization": `Bearer ${token}`}
         });
-        return {
-            data: res.data,
-            headers: res.headers,
-            status: res.status,
-        };
+        return res.data;
     }
 
-    public async issuePostRequest<T>(path: string, body: any, requestOptions?: RequestOptions): Promise<APIResponse<T>> {
+    public async issuePostRequest<T>(path: string, body: any, requestOptions?: RequestOptions): Promise<T> {
         const token = this.authProvider.signJwt(path, body);
         const headers: any = {"Authorization": `Bearer ${token}`};
         const idempotencyKey = requestOptions?.idempotencyKey;
         if (idempotencyKey) {
             headers["Idempotency-Key"] = idempotencyKey;
         }
-        const response = await this.axiosInstance.post(path, body, {headers});
-        return {
-            data: response.data,
-            headers: response.headers,
-            status: response.status,
-        };
+        const response = await this.axiosInstance.post<T>(path, body, {headers});
+        return response.data;
     }
 
-    public async issuePutRequest<T>(path: string, body: any): Promise<APIResponse<T>> {
+    public async issuePutRequest<T>(path: string, body: any): Promise<T> {
         const token = this.authProvider.signJwt(path, body);
-        const res = (await this.axiosInstance.put(path, body, {
+        const res = (await this.axiosInstance.put<T>(path, body, {
             headers: {"Authorization": `Bearer ${token}`}
         }));
-        return {
-            data: res.data,
-            headers: res.headers,
-            status: res.status,
-        };
+        return res.data;
     }
 
-    public async issuePatchRequest<T>(path: string, body: any): Promise<APIResponse<T>> {
+    public async issuePatchRequest<T>(path: string, body: any): Promise<T> {
         const token = this.authProvider.signJwt(path, body);
-        const res = (await this.axiosInstance.patch(path, body, {
+        const res = (await this.axiosInstance.patch<T>(path, body, {
             headers: {"Authorization": `Bearer ${token}`}
         }));
-        return {
-            data: res.data,
-            headers: res.headers,
-            status: res.status,
-        };
+        return res.data;
     }
 
-    public async issueDeleteRequest<T>(path: string): Promise<APIResponse<T>> {
+    public async issueDeleteRequest<T>(path: string): Promise<T> {
         const token = this.authProvider.signJwt(path);
-        const res = (await this.axiosInstance.delete(path, {
+        const res = (await this.axiosInstance.delete<T>(path, {
             headers: {"Authorization": `Bearer ${token}`}
         }));
-        return {
-            data: res.data,
-            headers: res.headers,
-            status: res.status,
-        };
+        return res.data;
     }
 }

--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -116,16 +116,6 @@ export class FireblocksSDK {
     public async getSupportedAssets(): Promise<APIResponse<AssetTypeResponse[]>> {
         return await this.apiClient.issueGetRequest("/v1/supported_assets");
     }
-
-    /**
-     * @deprecated this method is deprecated and will be removed in the future. Please use getVaultAccountsWithPageInfo instead.
-     * Gets all vault accounts for your tenant
-     */
-    public async getVaultAccounts(filter?: VaultAccountsFilter): Promise<APIResponse<VaultAccountResponse[]>> {
-        const url = `/v1/vault/accounts?${queryString.stringify(filter)}`;
-        return await this.apiClient.issueGetRequest(url);
-    }
-
     /**
      * Gets a list of vault accounts per page matching the given filter or path
      * @param pagedVaultAccountsRequestFilters Filters for the first request
@@ -133,16 +123,6 @@ export class FireblocksSDK {
     public async getVaultAccountsWithPageInfo(pagedVaultAccountsRequestFilters: PagedVaultAccountsRequestFilters): Promise<APIResponse<PagedVaultAccountsResponse>> {
         return await this.apiClient.issueGetRequest(`/v1/vault/accounts_paged?${queryString.stringify(pagedVaultAccountsRequestFilters)}`);
     }
-
-    /**
-     * @deprecated Replaced by getVaultAccountById.
-     * Gets a single vault account
-     * @param vaultAccountId The vault account ID
-     */
-    public async getVaultAccount(vaultAccountId: string): Promise<APIResponse<VaultAccountResponse>> {
-        return await this.getVaultAccountById(vaultAccountId);
-    }
-
     /**
      * Gets a single vault account
      * @param vaultAccountId The vault account ID
@@ -327,14 +307,6 @@ export class FireblocksSDK {
         return await this.apiClient.issueGetRequest("/v1/exchange_accounts");
     }
 
-    /**
-     * @deprecated Replaced by getExchangeAccountById
-     * Gets a single exchange account by ID
-     * @param exchangeAccountId The exchange account ID
-     */
-    public async getExchangeAccount(exchangeAccountId: string): Promise<APIResponse<ExchangeResponse>> {
-        return await this.getExchangeAccount(exchangeAccountId);
-    }
 
     /**
      * Gets a single exchange account by ID

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,11 @@ export interface Web3PagedResponse<T> {
     paging?: Paging;
 }
 
+export type APIResponseHeaders = AxiosResponseHeaders & {"x-request-id"?: string};
+
 export interface APIResponse<T> {
     data: T;
-    headers?: AxiosResponseHeaders;
+    headers?: APIResponseHeaders;
 }
 
 export interface VaultAccountResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,12 +7,6 @@ export interface Web3PagedResponse<T> {
 
 export type APIResponseHeaders = AxiosResponseHeaders & {"x-request-id"?: string};
 
-export interface APIResponse<T> {
-    data: T;
-    status?: number;
-    headers?: APIResponseHeaders;
-}
-
 export interface VaultAccountResponse {
     id: string;
     name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type APIResponseHeaders = AxiosResponseHeaders & {"x-request-id"?: string
 
 export interface APIResponse<T> {
     data: T;
+    status?: number;
     headers?: APIResponseHeaders;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,15 @@
+import { AxiosResponseHeaders } from "axios";
+
+export interface Web3PagedResponse<T> {
+    data: T[];
+    paging?: Paging;
+}
+
+export interface APIResponse<T> {
+    data: T;
+    headers?: AxiosResponseHeaders;
+}
+
 export interface VaultAccountResponse {
     id: string;
     name: string;
@@ -487,7 +499,6 @@ export interface NFTOwnershipFilter {
     pageSize?: number;
 }
 
-
 class MediaEntity {
     url: string;
     contentType: string;
@@ -501,11 +512,6 @@ interface NFTCollection {
 
 export interface Paging {
     next: string;
-}
-
-export interface APIPagedResponse<T> {
-    data: T[];
-    paging?: Paging;
 }
 
 export interface Token {
@@ -712,6 +718,17 @@ export interface PublicKeyResponse {
     algorithm: string;
     derivationPath: number[];
     publicKey: string;
+}
+
+export interface PublicKeyInformation {
+    algorithm: string;
+    derivationPath: number[];
+    publicKey: String;
+}
+
+export interface DropTransactionResponse {
+    success: boolean;
+    transactions?: string[];
 }
 
 export interface MaxSpendableAmountResponse {


### PR DESCRIPTION
BREAKING CHANGE: removed all deprecated SDK methods

## Pull Request Description

- Adding support for providing an axios response interceptor (https://axios-http.com/docs/interceptors)
- Removing deprecated methods

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [X] Locally tested against Fireblocks API

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have added corresponding labels to the PR
