### PR TITLE
Change balance to string in nft token ownership api

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -535,7 +535,7 @@ export interface Token {
 }
 
 export interface TokenWithBalance extends Token {
-    balance: number;
+    balance: string;
     vaultAccountId: string;
     ownershipStartTime: number;
     ownershipLastUpdateTime: number;


### PR DESCRIPTION
## Pull Request Description

Changing balance type from number to string in nft token ownership response api.

Fixes (link to the issue here)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
