### PR TITLE
Make travelRuleOptions field optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ interface SDKOptions {
     userAgent?: string;
     
     /** TravelRule Provider options to initialize PII Client for PII encryption */
-    travelRuleOptions: TravelRuleOptions;
+    travelRuleOptions?: TravelRuleOptions;
 }
 ```
 

--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -111,7 +111,7 @@ export interface SDKOptions {
     /**
      * TravelRule Provider options to initialize PII Client for PII encryption
      */
-    travelRuleOptions: TravelRuleOptions;
+    travelRuleOptions?: TravelRuleOptions;
 }
 
 export class FireblocksSDK {


### PR DESCRIPTION
## Pull Request Description

Make `travelRuleOptions` field optional

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
