### PR TITLE
Add Smart Transfers user groups endpoints

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -92,6 +92,7 @@ import {
     SmartTransfersTicketTermPayload,
     SmartTransfersTicketTermFundPayload,
     SmartTransfersTicketTermResponse,
+    SmartTransfersUserGroupsResponse,
     UsersGroup,
     ContractUploadRequest,
     ContractTemplateDto,
@@ -1743,6 +1744,21 @@ export class FireblocksSDK {
      */
     public manuallyFundSmartTransferTicketTerms(ticketId: string, termId: string, txHash: string): Promise<SmartTransfersTicketTermResponse> {
         return this.apiClient.issuePutRequest(`/v1/smart-transfers/${ticketId}/terms/${termId}/manually-fund`, { txHash });
+    }
+
+    /**
+     * Set Smart Transfers user group ids. User group ids are used for Smart Transfer notifications
+     * @param userGroupIds
+     */
+    public setSmartTransferTicketUserGroups(userGroupIds: string[]): Promise<SmartTransfersUserGroupsResponse> {
+        return this.apiClient.issuePostRequest(`/v1/smart-transfers/settings/user-groups`, { userGroupIds });
+    }
+
+    /**
+     * Get Smart Transfers user group ids. User group ids are used for Smart Transfer notifications
+     */
+    public getSmartTransferTicketUserGroups(): Promise<SmartTransfersUserGroupsResponse> {
+        return this.apiClient.issueGetRequest(`/v1/smart-transfers/settings/user-groups`);
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1598,6 +1598,14 @@ export interface SmartTransfersTicketsFilters {
     type?: string;
 }
 
+export interface SmartTransfersUserGroupsResponse {
+    data: SmartTransfersUserGroups;
+}
+
+export interface SmartTransfersUserGroups {
+    userGroupIds: string[];
+}
+
 export interface SmartTransfersTicketTermFundPayload {
     asset: string;
     amount: string;


### PR DESCRIPTION
## Pull Request Description

Adds new endpoints for Smart Transfers feature for storing and getting user groups that are used in notifications.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
