### PR TITLE
Add multi NFT ownership status update endpoint

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -76,6 +76,7 @@ import {
     TokenLinkPermissionEntry,
     IssueTokenRequest,
     NFTOwnershipStatus,
+    NFTOwnershipStatusUpdatedPayload,
     NFTOwnedCollectionsFilter,
     CollectionOwnership,
     TravelRuleOptions,
@@ -1545,6 +1546,15 @@ export class FireblocksSDK {
      */
     public async updateNFTOwnershipStatus(id: string, status: NFTOwnershipStatus): Promise<void> {
         return await this.apiClient.issuePutRequest(`/v1/nfts/ownership/tokens/${id}/status`, { status });
+    }
+
+    /**
+     *
+     * Updates tokens status for a tenant, in all tenant vaults.
+     * @param payload List of assets with status for update
+     */
+    public async updateNFTOwnershipsStatus(payload: NFTOwnershipStatusUpdatedPayload[]): Promise<void> {
+        return await this.apiClient.issuePutRequest(`/v1/nfts/ownership/tokens/status`, payload);
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1477,6 +1477,11 @@ export enum NFTOwnershipStatus {
     "ARCHIVED" = "ARCHIVED",
 }
 
+export interface NFTOwnershipStatusUpdatedPayload {
+    assetId: string;
+    status: NFTOwnershipStatus;
+}
+
 export enum NFTOwnershipWalletType {
     "VAULT_ACCOUNT" = "VAULT_ACCOUNT",
     "END_USER_WALLET" = "END_USER_WALLET",


### PR DESCRIPTION
## Pull Request Description
This pull request adds the multi NFT status update endpoint.

Fixes (link to the issue here)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
