### PR TITLE
Update transaction response metadata using API reference

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -645,6 +645,7 @@ export interface FeePayerInfo {
 export interface TransactionResponse {
     id: string;
     assetId: string;
+    operation: string;
     source: TransferPeerPathResponse;
     destination: TransferPeerPathResponse;
     amount: number;
@@ -705,6 +706,9 @@ export interface FeeInfo {
 export interface TransactionResponseDestination {
     amount?: string;
     amountUSD?: string;
+    customerRefId?: string;
+    destinationAddress?: string;
+    destinationAddressDescription?: string;
     amlScreeningResult?: AmlScreeningResult;
     destination?: TransferPeerPathResponse;
     authorizationInfo?: AuthorizationInfo;


### PR DESCRIPTION
## Pull Request Description

There seems to be some discrepancy between the response for Get Transaction By ID in the API Reference and that of the SDK. This PR adds the new properties to the SDK transaction response definition

Fixes (link to the issue here)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
