### PR TITLE
remove old api endpoint; implement "internal_transfer"

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -510,39 +510,24 @@ export class FireblocksSDK {
     }
 
     /**
-     * Transfer from a main exchange account to a subaccount
+     * Internal Transfer from a main exchange account to a subaccount
      * @param exchangeAccountId The exchange ID in Fireblocks
      * @param subaccountId The ID of the subaccount in the exchange
      * @param assetId The asset to transfer
      * @param amount The amount to transfer
+     * @param note A description of the transfer
      * @param requestOptions
      */
-    public async transferToSubaccount(exchangeAccountId: string, subaccountId: string, assetId: string, amount: number, requestOptions?: RequestOptions): Promise<OperationSuccessResponse> {
-        const body = {
-            subaccountId,
-            amount
-        };
+    public async internalTransfer(exchangeAccountId: string, subaccountId: string, assetId: string, amount: number, note: string, requestOptions?: RequestOptions): Promise<OperationSuccessResponse> {
+      const body = {
+          subaccountId,
+          assetId,
+          amount,
+          note
+      };
 
-        return await this.apiClient.issuePostRequest(`/v1/exchange_accounts/${exchangeAccountId}/${assetId}/transfer_to_subaccount`, body, requestOptions);
-    }
-
-    /**
-     * Transfer from a subaccount to a main exchange account
-     * @param exchangeAccountId The exchange ID in Fireblocks
-     * @param subaccountId The ID of the subaccount in the exchange
-     * @param assetId The asset to transfer
-     * @param amount The amount to transfer
-     * @param requestOptions
-     */
-    public async transferFromSubaccount(exchangeAccountId: string, subaccountId: string, assetId: string, amount: number, requestOptions?: RequestOptions): Promise<OperationSuccessResponse> {
-        const body = {
-            subaccountId,
-            amount
-        };
-
-        return await this.apiClient.issuePostRequest(`/v1/exchange_accounts/${exchangeAccountId}/${assetId}/transfer_from_subaccount`, body, requestOptions);
-    }
-
+      return await this.apiClient.issuePostRequest(`/v1/exchange_accounts/${exchangeAccountId}/internal_transfer`, body, requestOptions);
+  }
     /**
      * Gets all fiat accounts for your tenant
      */


### PR DESCRIPTION
## Pull Request Description

It appears there are two obsolete endpoints in the code: *transfer_to_subaccount* and *transfer_from_subaccount*

Fixes (link to the issue here)
I have deleted these and replaced with the newer version *internal_transfer*

## Type of change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
not tested

## Checklist:

- [ X ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
