### PR TITLE
Revert mistake in updateVaultAccount

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -778,12 +778,12 @@ export class FireblocksSDK {
      * @param vaultAccountId
      * @param name A new name for the vault account
      */
-    public async updateVaultAccount(vaultAccountId: string, name: string, requestOptions?: RequestOptions): Promise<VaultAccountResponse> {
+    public async updateVaultAccount(vaultAccountId: string, name: string): Promise<VaultAccountResponse> {
         const body = {
             name: name
         };
 
-        return await this.apiClient.issuePostRequest(`/v1/vault/accounts/${vaultAccountId}`, body, requestOptions);
+        return await this.apiClient.issuePutRequest(`/v1/vault/accounts/${vaultAccountId}`, body);
     }
 
     /**


### PR DESCRIPTION
## Pull Request Description

Function updateVaultAccount used post instead of put, and had a redundant parameter. This commit fixes that.

Fixes (link to the issue here)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [X] Locally tested against Fireblocks API

## Checklist:

- [X] I have performed a self-review of my own code
- [n/a ] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [n/a] I have added corresponding labels to the PR
