### PR TITLE
 Exposing external aml endpoints for screening setting

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -118,7 +118,7 @@ import {
     ContractAbiResponseDto,
     DeployedContractResponseDto,
     LeanDeployedContractResponseDto,
-    ParameterWithValueList, ScreeningTenantConfiguration,
+    ParameterWithValueList, ScreeningTenantConfiguration, ScreeningType,
 } from "./types";
 import { AxiosProxyConfig, AxiosResponse } from "axios";
 import { PIIEncryption } from "./pii-client";
@@ -1867,61 +1867,40 @@ export class FireblocksSDK {
     }
 
     /**
-     * Get PostScreening Policies for travel rule compliance
+     * Get PostScreening Policies for compliance
+     * @param screeningType The type of screening (e.g., 'travel_rule', 'aml')
      */
-    public async getTravelRulePostScreeningPolicy(): Promise<TravelRuleRulesConfiguration> {
-        return await this.apiClient.issueGetRequest(`/v1/screening/travel_rule/post_screening_policy`);
+    private async getPostScreeningPolicy(screeningType: ScreeningType): Promise<any> {
+        const endpoint = `/v1/screening/${screeningType}/post_screening_policy`;
+        return await this.apiClient.issueGetRequest(endpoint);
     }
 
     /**
-     * Get Screening Policies for travel rule compliance
+     * Get Screening Policies for compliance
+     * @param screeningType The type of screening (e.g., 'travel_rule', 'aml')
      */
-    public async getTravelRuleScreeningPolicy(): Promise<TravelRulePolicy> {
-        return await this.apiClient.issueGetRequest(`/v1/screening/travel_rule/screening_policy`);
+    private async getScreeningPolicy(screeningType: ScreeningType): Promise<any> {
+        const endpoint = `/v1/screening/${screeningType}/screening_policy`;
+        return await this.apiClient.issueGetRequest(endpoint);
     }
 
     /**
-     * Get Screening Configuration for travel rule compliance
+     * Get Screening Configuration for compliance
+     * @param screeningType The type of screening (e.g., 'travel_rule', 'aml')
      */
-    public async getTravelRuleScreeningConfiguration(): Promise<ScreeningPolicyConfiguration> {
-        return await this.apiClient.issueGetRequest(`/v1/screening/travel_rule/policy_configuration`);
+    private async getScreeningConfiguration(screeningType: ScreeningType): Promise<any> {
+        const endpoint = `/v1/screening/${screeningType}/policy_configuration`;
+        return await this.apiClient.issueGetRequest(endpoint);
     }
 
     /**
-     * Update Bypass Screening Configuration for travel rule compliance
-     * @param screeningPolicyConfiguration
+     * Update Bypass Screening Configuration for compliance
+     * @param screeningType The type of screening (e.g., 'travel_rule', 'aml')
+     * @param screeningPolicyConfiguration The configuration to update
      */
-    public async updateTravelRulePolicyConfiguration(screeningPolicyConfiguration: ScreeningPolicyConfiguration): Promise<ScreeningPolicyConfiguration> {
-        return await this.apiClient.issuePutRequest(`/v1/screening/travel_rule/policy_configuration`, screeningPolicyConfiguration);
-    }
-
-    /**
-     * Get PostScreening Policies for AML/KYT compliance
-     */
-    public async getTravelAMLScreeningPolicy(): Promise<TravelRuleRulesConfiguration> {
-        return await this.apiClient.issueGetRequest(`/v1/screening/aml/post_screening_policy`);
-    }
-
-    /**
-     * Get Screening Policies for AML/KYT compliance
-     */
-    public async getAMLScreeningPolicy(): Promise<TravelRulePolicy> {
-        return await this.apiClient.issueGetRequest(`/v1/screening/aml/screening_policy`);
-    }
-
-    /**
-     * Get Screening Configuration for AML/KYT compliance
-     */
-    public async getAMLScreeningConfiguration(): Promise<ScreeningPolicyConfiguration> {
-        return await this.apiClient.issueGetRequest(`/v1/screening/aml/policy_configuration`);
-    }
-
-    /**
-     * Update Bypass Screening Configuration for AML/KYT compliance
-     * @param screeningPolicyConfiguration
-     */
-    public async updateAMLPolicyConfiguration(screeningPolicyConfiguration: ScreeningPolicyConfiguration): Promise<ScreeningPolicyConfiguration> {
-        return await this.apiClient.issuePutRequest(`/v1/screening/aml/policy_configuration`, screeningPolicyConfiguration);
+    private async updatePolicyConfiguration(screeningType: ScreeningType, screeningPolicyConfiguration: any): Promise<any> {
+        const endpoint = `/v1/screening/${screeningType}/policy_configuration`;
+        return await this.apiClient.issuePutRequest(endpoint, screeningPolicyConfiguration);
     }
 
     /**

--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -118,7 +118,7 @@ import {
     ContractAbiResponseDto,
     DeployedContractResponseDto,
     LeanDeployedContractResponseDto,
-    ParameterWithValueList,
+    ParameterWithValueList, ScreeningTenantConfiguration,
 } from "./types";
 import { AxiosProxyConfig, AxiosResponse } from "axios";
 import { PIIEncryption } from "./pii-client";
@@ -1893,6 +1893,43 @@ export class FireblocksSDK {
      */
     public async updateTravelRulePolicyConfiguration(screeningPolicyConfiguration: ScreeningPolicyConfiguration): Promise<ScreeningPolicyConfiguration> {
         return await this.apiClient.issuePutRequest(`/v1/screening/travel_rule/policy_configuration`, screeningPolicyConfiguration);
+    }
+
+    /**
+     * Get PostScreening Policies for AML/KYT compliance
+     */
+    public async getTravelAMLScreeningPolicy(): Promise<TravelRuleRulesConfiguration> {
+        return await this.apiClient.issueGetRequest(`/v1/screening/aml/post_screening_policy`);
+    }
+
+    /**
+     * Get Screening Policies for AML/KYT compliance
+     */
+    public async getAMLScreeningPolicy(): Promise<TravelRulePolicy> {
+        return await this.apiClient.issueGetRequest(`/v1/screening/aml/screening_policy`);
+    }
+
+    /**
+     * Get Screening Configuration for AML/KYT compliance
+     */
+    public async getAMLScreeningConfiguration(): Promise<ScreeningPolicyConfiguration> {
+        return await this.apiClient.issueGetRequest(`/v1/screening/aml/policy_configuration`);
+    }
+
+    /**
+     * Update Bypass Screening Configuration for AML/KYT compliance
+     * @param screeningPolicyConfiguration
+     */
+    public async updateAMLPolicyConfiguration(screeningPolicyConfiguration: ScreeningPolicyConfiguration): Promise<ScreeningPolicyConfiguration> {
+        return await this.apiClient.issuePutRequest(`/v1/screening/aml/policy_configuration`, screeningPolicyConfiguration);
+    }
+
+    /**
+     * Update Bypass Screening Configuration for AML/KYT compliance
+     * @param screeningTenantConfiguration
+     */
+    public async updateTenantScreeningConfiguration(screeningTenantConfiguration: ScreeningTenantConfiguration): Promise<ScreeningTenantConfiguration> {
+        return await this.apiClient.issuePutRequest(`/v1/screening/config`, screeningTenantConfiguration);
     }
 
     /**

--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -95,8 +95,6 @@ import {
     SmartTransfersTicketTermPayload,
     SmartTransfersTicketTermFundPayload,
     ScreeningPolicyConfiguration,
-    TravelRulePolicy,
-    TravelRuleRulesConfiguration,
     SmartTransfersTicketTermResponse,
     SmartTransfersUserGroupsResponse,
     UsersGroup,
@@ -118,7 +116,11 @@ import {
     ContractAbiResponseDto,
     DeployedContractResponseDto,
     LeanDeployedContractResponseDto,
-    ParameterWithValueList, ScreeningTenantConfiguration, ScreeningType,
+    ParameterWithValueList,
+    ScreeningTenantConfiguration,
+    ScreeningType,
+    ScreeningConfigurationsResponse,
+    ScreeningPolicyRuleResponse, ScreeningProviderConfigurationResponse,
 } from "./types";
 import { AxiosProxyConfig, AxiosResponse } from "axios";
 import { PIIEncryption } from "./pii-client";
@@ -1870,7 +1872,7 @@ export class FireblocksSDK {
      * Get PostScreening Policies for compliance
      * @param screeningType The type of screening (e.g., 'travel_rule', 'aml')
      */
-    private async getPostScreeningPolicy(screeningType: ScreeningType): Promise<any> {
+    private async getPostScreeningPolicy(screeningType: ScreeningType): Promise<ScreeningProviderConfigurationResponse> {
         const endpoint = `/v1/screening/${screeningType}/post_screening_policy`;
         return await this.apiClient.issueGetRequest(endpoint);
     }
@@ -1879,7 +1881,7 @@ export class FireblocksSDK {
      * Get Screening Policies for compliance
      * @param screeningType The type of screening (e.g., 'travel_rule', 'aml')
      */
-    private async getScreeningPolicy(screeningType: ScreeningType): Promise<any> {
+    private async getScreeningPolicy(screeningType: ScreeningType): Promise<ScreeningPolicyRuleResponse> {
         const endpoint = `/v1/screening/${screeningType}/screening_policy`;
         return await this.apiClient.issueGetRequest(endpoint);
     }
@@ -1888,7 +1890,7 @@ export class FireblocksSDK {
      * Get Screening Configuration for compliance
      * @param screeningType The type of screening (e.g., 'travel_rule', 'aml')
      */
-    private async getScreeningConfiguration(screeningType: ScreeningType): Promise<any> {
+    private async getScreeningConfiguration(screeningType: ScreeningType): Promise<ScreeningConfigurationsResponse> {
         const endpoint = `/v1/screening/${screeningType}/policy_configuration`;
         return await this.apiClient.issueGetRequest(endpoint);
     }
@@ -1898,13 +1900,13 @@ export class FireblocksSDK {
      * @param screeningType The type of screening (e.g., 'travel_rule', 'aml')
      * @param screeningPolicyConfiguration The configuration to update
      */
-    private async updatePolicyConfiguration(screeningType: ScreeningType, screeningPolicyConfiguration: any): Promise<any> {
+    private async updatePolicyConfiguration(screeningType: ScreeningType, screeningPolicyConfiguration: ScreeningPolicyConfiguration): Promise<ScreeningConfigurationsResponse> {
         const endpoint = `/v1/screening/${screeningType}/policy_configuration`;
         return await this.apiClient.issuePutRequest(endpoint, screeningPolicyConfiguration);
     }
 
     /**
-     * Update Bypass Screening Configuration for AML/KYT compliance
+     * Update Bypass Screening Tenant Configuration for AML/KYT compliance
      * @param screeningTenantConfiguration
      */
     public async updateTenantScreeningConfiguration(screeningTenantConfiguration: ScreeningTenantConfiguration): Promise<ScreeningTenantConfiguration> {

--- a/src/pii-client.ts
+++ b/src/pii-client.ts
@@ -43,9 +43,7 @@ export class PIIEncryption {
         };
         const { jsonDidKey } = this.config;
         const counterpartyDIDKey = travelRuleEncryptionOptions?.beneficiaryPIIDidKey;
-
-        console.log("pii", pii);
-
+        
         let piiIvms;
 
         try {

--- a/src/pii-client.ts
+++ b/src/pii-client.ts
@@ -44,6 +44,8 @@ export class PIIEncryption {
         const { jsonDidKey } = this.config;
         const counterpartyDIDKey = travelRuleEncryptionOptions?.beneficiaryPIIDidKey;
 
+        console.log("pii", pii);
+
         let piiIvms;
 
         try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -586,6 +586,8 @@ export interface TravelRulePolicy {
     lastUpdate: Date;
 }
 
+export type ScreeningType = "travel_rule" | "aml";
+
 export enum Web3ConnectionFeeLevel {
     HIGH = "HIGH",
     MEDIUM = "MEDIUM",

--- a/src/types.ts
+++ b/src/types.ts
@@ -517,13 +517,13 @@ export interface ScreeningTenantConfiguration {
     disableUnfreeze: boolean;
 }
 
-export enum TravelRuleAction {
+export enum ScreeningAction {
     screen = "SCREEN",
     pass = "PASS",
     freeze = "FREEZE"
 }
 
-export interface TravelRulePolicyRule {
+export interface ScreeningPolicyRuleResponse {
     sourceType?: string;
     sourceSubType?: string;
     destType?: string;
@@ -537,7 +537,16 @@ export interface TravelRulePolicyRule {
     amountUSD?: number;
     networkProtocol?: string;
     operation?: string;
-    action: TravelRuleAction;
+    action: ScreeningAction;
+}
+
+export interface ScreeningProviderConfigurationResponse {
+    direction?: TransactionDirection;
+    status?: TransactionStatusDirection;
+    amountUSD?: number;
+    amount?: number;
+    asset?: string;
+    action: ScreeningVerdict;
 }
 
 export enum PolicyApprovalStatus {
@@ -550,7 +559,7 @@ export enum TransactionDirection {
     outbound = "OUTBOUND"
 }
 
-export enum FbTravelRuleTransactionStatus {
+export enum TransactionStatusDirection {
     completed = "COMPLETED",
     pending = "PENDING",
     rejected = "REJECTED",
@@ -559,7 +568,7 @@ export enum FbTravelRuleTransactionStatus {
     blockingTimeExpired = "BLOCKING_TIME_EXPIRED",
 }
 
-export enum TravelRuleVerdict {
+export enum ScreeningVerdict {
     accept = "ACCEPT",
     reject = "REJECT",
     alert = "ALERT",
@@ -568,22 +577,36 @@ export enum TravelRuleVerdict {
     cancel = "CANCEL"
 }
 
-export interface TravelRuleRulesConfiguration {
-    direction?: TransactionDirection;
-    status?: FbTravelRuleTransactionStatus;
-    amountUSD?: number;
-    amount?: number;
-    asset?: string;
-    action: TravelRuleVerdict;
+export interface ScreeningConfigurationsResponse {
+    bypassScreeningDuringServiceOutages: boolean;
+    inboundTransactionDelay: number;
+    outboundTransactionDelay: number;
 }
 
-export interface TravelRulePolicy {
+export interface ScreeningPolicyResponse {
     tenantId?: string;
-    policy: TravelRulePolicyRule[];
+    policy: ScreeningPolicyRuleResponse;
     policyStatus?: PolicyApprovalStatus;
     isDefault: boolean;
     createDate?: Date;
     lastUpdate: Date;
+}
+
+export interface ScreeningPolicyRuleResponse {
+    sourceType?: string;
+    sourceSubType?: string;
+    destType?: string;
+    destSubType?: string;
+    destAddress?: string;
+    sourceId?: string;
+    destId?: string;
+    asset?: string;
+    baseAsset?: string;
+    amount?: number;
+    amountUSD?: number;
+    networkProtocol?: string;
+    operation?: string;
+    action: ScreeningAction;
 }
 
 export type ScreeningType = "travel_rule" | "aml";

--- a/src/types.ts
+++ b/src/types.ts
@@ -512,6 +512,11 @@ export interface ScreeningPolicyConfiguration {
     outboundTransactionDelay?: number;
 }
 
+export interface ScreeningTenantConfiguration {
+    disableBypass: boolean;
+    disableUnfreeze: boolean;
+}
+
 export enum TravelRuleAction {
     screen = "SCREEN",
     pass = "PASS",

--- a/src/types.ts
+++ b/src/types.ts
@@ -542,7 +542,7 @@ export interface ScreeningPolicyRuleResponse {
 
 export interface ScreeningProviderConfigurationResponse {
     direction?: TransactionDirection;
-    status?: TransactionStatusDirection;
+    status?: ScreeningTransactionStatus;
     amountUSD?: number;
     amount?: number;
     asset?: string;
@@ -559,7 +559,7 @@ export enum TransactionDirection {
     outbound = "OUTBOUND"
 }
 
-export enum TransactionStatusDirection {
+export enum ScreeningTransactionStatus {
     completed = "COMPLETED",
     pending = "PENDING",
     rejected = "REJECTED",


### PR DESCRIPTION
## Pull Request Description

View AML screening / post screening policy
Bypass screening during service outages, inbound and outband transaction delay
Expose endpoint for Screening setting

Fixes (link to the issue here)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
