### PR TITLE
Fix empty querystring scenario

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -107,9 +107,9 @@ export class ApiClient {
 }
 
 /** 
-* This function allows backward compatibility with previous version of axois that did not omit ? for 
-* urls with no params. This function will make sure we are omitting the ? before signing it
-*/
+ * This function allows backward compatibility with previous version of axois that did not omit ? for 
+ * urls with no params. This function will make sure we are omitting the ? before signing it
+ */
 function normalizePath(path: string) {
     return path.replace(/\?$/, "");
 }

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -37,7 +37,7 @@ export class ApiClient {
     }
 
     public async issueGetRequestForTransactionPages(rawPath: string): Promise<TransactionPageResponse> {
-        const path = normalizePath(rawPath)
+        const path = normalizePath(rawPath);
         const token = this.authProvider.signJwt(path);
         const res = await this.axiosInstance.get(path, {
             headers: {"Authorization": `Bearer ${token}`}
@@ -52,7 +52,7 @@ export class ApiClient {
     }
 
     public async issueGetRequest<T>(rawPath: string): Promise<T> {
-        const path = normalizePath(rawPath)
+        const path = normalizePath(rawPath);
         const token = this.authProvider.signJwt(path);
         const res = await this.axiosInstance.get(path, {
             headers: {"Authorization": `Bearer ${token}`}
@@ -61,7 +61,7 @@ export class ApiClient {
     }
 
     public async issuePostRequest<T>(rawPath: string, body: any, requestOptions?: RequestOptions): Promise<T> {
-        const path = normalizePath(rawPath)
+        const path = normalizePath(rawPath);
         const token = this.authProvider.signJwt(path, body);
         const headers: any = {"Authorization": `Bearer ${token}`};
         const idempotencyKey = requestOptions?.idempotencyKey;
@@ -79,7 +79,7 @@ export class ApiClient {
     }
 
     public async issuePutRequest<T>(rawPath: string, body: any): Promise<T> {
-        const path = normalizePath(rawPath)
+        const path = normalizePath(rawPath);
         const token = this.authProvider.signJwt(path, body);
         const res = (await this.axiosInstance.put<T>(path, body, {
             headers: {"Authorization": `Bearer ${token}`}
@@ -88,7 +88,7 @@ export class ApiClient {
     }
 
     public async issuePatchRequest<T>(rawPath: string, body: any): Promise<T> {
-        const path = normalizePath(rawPath)
+        const path = normalizePath(rawPath);
         const token = this.authProvider.signJwt(path, body);
         const res = (await this.axiosInstance.patch<T>(path, body, {
             headers: {"Authorization": `Bearer ${token}`}
@@ -97,7 +97,7 @@ export class ApiClient {
     }
 
     public async issueDeleteRequest<T>(rawPath: string): Promise<T> {
-        const path = normalizePath(rawPath)
+        const path = normalizePath(rawPath);
         const token = this.authProvider.signJwt(path);
         const res = (await this.axiosInstance.delete<T>(path, {
             headers: {"Authorization": `Bearer ${token}`}

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -106,8 +106,10 @@ export class ApiClient {
     }
 }
 
-// This function allows backward compatibility with previous version of axois that did not omit ? for 
-// urls with no params. This function will make sure we are omitting the ? before signing it
+/** 
+ * This function allows backward compatibility with previous version of axois that did not omit ? for 
+ * urls with no params. This function will make sure we are omitting the ? before signing it
+*/
 function normalizePath(path: string) {
     return path.replace(/\?$/, "");
 }

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -107,8 +107,8 @@ export class ApiClient {
 }
 
 /** 
- * This function allows backward compatibility with previous version of axois that did not omit ? for 
- * urls with no params. This function will make sure we are omitting the ? before signing it
+* This function allows backward compatibility with previous version of axois that did not omit ? for 
+* urls with no params. This function will make sure we are omitting the ? before signing it
 */
 function normalizePath(path: string) {
     return path.replace(/\?$/, "");

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -36,7 +36,8 @@ export class ApiClient {
         return userAgent;
     }
 
-    public async issueGetRequestForTransactionPages(path: string): Promise<TransactionPageResponse> {
+    public async issueGetRequestForTransactionPages(rawPath: string): Promise<TransactionPageResponse> {
+        const path = normalizePath(rawPath)
         const token = this.authProvider.signJwt(path);
         const res = await this.axiosInstance.get(path, {
             headers: {"Authorization": `Bearer ${token}`}
@@ -50,7 +51,8 @@ export class ApiClient {
         };
     }
 
-    public async issueGetRequest<T>(path: string): Promise<T> {
+    public async issueGetRequest<T>(rawPath: string): Promise<T> {
+        const path = normalizePath(rawPath)
         const token = this.authProvider.signJwt(path);
         const res = await this.axiosInstance.get(path, {
             headers: {"Authorization": `Bearer ${token}`}
@@ -58,7 +60,8 @@ export class ApiClient {
         return res.data;
     }
 
-    public async issuePostRequest<T>(path: string, body: any, requestOptions?: RequestOptions): Promise<T> {
+    public async issuePostRequest<T>(rawPath: string, body: any, requestOptions?: RequestOptions): Promise<T> {
+        const path = normalizePath(rawPath)
         const token = this.authProvider.signJwt(path, body);
         const headers: any = {"Authorization": `Bearer ${token}`};
         const idempotencyKey = requestOptions?.idempotencyKey;
@@ -75,7 +78,8 @@ export class ApiClient {
         return response.data;
     }
 
-    public async issuePutRequest<T>(path: string, body: any): Promise<T> {
+    public async issuePutRequest<T>(rawPath: string, body: any): Promise<T> {
+        const path = normalizePath(rawPath)
         const token = this.authProvider.signJwt(path, body);
         const res = (await this.axiosInstance.put<T>(path, body, {
             headers: {"Authorization": `Bearer ${token}`}
@@ -83,7 +87,8 @@ export class ApiClient {
         return res.data;
     }
 
-    public async issuePatchRequest<T>(path: string, body: any): Promise<T> {
+    public async issuePatchRequest<T>(rawPath: string, body: any): Promise<T> {
+        const path = normalizePath(rawPath)
         const token = this.authProvider.signJwt(path, body);
         const res = (await this.axiosInstance.patch<T>(path, body, {
             headers: {"Authorization": `Bearer ${token}`}
@@ -91,11 +96,18 @@ export class ApiClient {
         return res.data;
     }
 
-    public async issueDeleteRequest<T>(path: string): Promise<T> {
+    public async issueDeleteRequest<T>(rawPath: string): Promise<T> {
+        const path = normalizePath(rawPath)
         const token = this.authProvider.signJwt(path);
         const res = (await this.axiosInstance.delete<T>(path, {
             headers: {"Authorization": `Bearer ${token}`}
         }));
         return res.data;
     }
+}
+
+// This function allows backward compatibility with previous version of axois that did not omit ? for 
+// urls with no params. This function will make sure we are omitting the ? before signing it
+function normalizePath(path: string) {
+    return path.replace(/\?$/, "");
 }


### PR DESCRIPTION
## Pull Request Description

After the latest `axios` upgrade from 0.27.2 to 1.6.0 for URLs with `?` but no params the `?` character is omitted and we get a situation that we are signing `https://path/to/somwehere? ` but sending the request to `https://path/to/somewhere`, resulting with a signing error

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
