### PR TITLE
update type of addressFormat to string | undefined

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1195,7 +1195,7 @@ export interface AddressResponse {
     tag: string;
     type?: number;
     customerRefId?: number;
-    addressFormat: number;
+    addressFormat?: string;
     legacyAddress?: string;
     enterpriseAddress?: string;
     bip44AddressIndex?: string;


### PR DESCRIPTION
## Pull Request Description

The bug fix involves correcting the data type for the addressFormat property in the SDK code. Currently, the addressFormat is defined as a number in the code. The correction should update the data type to a string | undefined for the addressFormat property in the AddressResponse interface. This adjustment ensures consistency and compatibility with the actual data type used for addressFormat in the underlying implementation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran build command and used the new custom SDK in my Express app. Works fine now and I do not see the compile-time error. I am using Typescript in the Express app.

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
