### PR TITLE
Add `errorDescription` to `TransactionResponse`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -717,6 +717,7 @@ export interface TransactionResponse {
     index?: number;
     rewardInfo?: RewardInfo;
     feePayerInfo?: FeePayerInfo;
+    errorDescription?: string;
 }
 
 export interface AmountInfo {


### PR DESCRIPTION
## Pull Request Description

The `errorDescription` field contains the smart contract error message when a transaction's `subStatus` is equal to `SMART_CONTRACT_EXECUTION_FAILED`.