### PR TITLE
fix response type of address_paginated endpoint

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1234,7 +1234,7 @@ export interface AddressResponse {
     address: string;
     description?: string;
     tag: string;
-    type?: number;
+    type?: string;
     customerRefId?: number;
     addressFormat?: string;
     legacyAddress?: string;


### PR DESCRIPTION
## Pull Request Description
This PR fixes wrong typing of the response in `/vault/accounts/:vaultAccountId/:assetId/addresses_paginated` endpoint, particularly `type` property of the response. For some reason it was set as `number` in the sdk, but in docs it is `string` and in fact in the response the return type is `string`.
Screenshot attached with the response from the sandbox environment.

<img width="993" alt="image" src="https://github.com/fireblocks/fireblocks-sdk-js/assets/63240495/ef6e8852-bbf9-406a-8530-1dde0d7a3581">


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Locally tested against Fireblocks API

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have added corresponding labels to the PR
