### PR TITLE
functions instead of abi

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -1976,7 +1976,7 @@ export class FireblocksSDK {
      * @returns {ContractAbiResponseDto}
      */
     public async getContractAbi(baseAssetId: string, contractAddress: string): Promise<ContractAbiResponseDto> {
-        return await this.apiClient.issueGetRequest(`/v1/contract_interactions/base_asset_id/${baseAssetId}/contract_address/${contractAddress}/abi`);
+        return await this.apiClient.issueGetRequest(`/v1/contract_interactions/base_asset_id/${baseAssetId}/contract_address/${contractAddress}/functions`);
     }
 
     /**


### PR DESCRIPTION
## Pull Request Description

endpoint /v1/contract_interactions/base_asset_id/{assetId}/contract_address/{contractAddress}/functions is pointing to 
v1/contract_interactions/base_asset_id/{assetId}/contract_address/{contractAddress}/abi

changed abi -> functions path param

Fixes (link to the issue here)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
