### PR TITLE
NCW Asset Response for Balance and Refresh Balance differs from that …

### DIFF
--- a/src/ncw-sdk.ts
+++ b/src/ncw-sdk.ts
@@ -1,5 +1,5 @@
 import {
-    AssetResponse, Web3PagedResponse, NCW, UnspentInputsResponse,
+    AssetResponseNCW, Web3PagedResponse, NCW, UnspentInputsResponse,
     SigningAlgorithm,
 } from "./types";
 
@@ -155,7 +155,7 @@ export interface NcwSdk {
      * @param {string} assetId
      * @return {*}  {Promise<AssetResponse>}
      */
-    getWalletAssetBalance(walletId: string, accountId: number, assetId: string): Promise<AssetResponse>;
+    getWalletAssetBalance(walletId: string, accountId: number, assetId: string): Promise<AssetResponseNCW>;
 
     /**
      * refresh a NCW asset balance
@@ -165,7 +165,7 @@ export interface NcwSdk {
      * @param {string} assetId
      * @return {*}  {Promise<AssetResponse>}
      */
-    refreshWalletAssetBalance(walletId: string, accountId: number, assetId: string): Promise<AssetResponse>;
+    refreshWalletAssetBalance(walletId: string, accountId: number, assetId: string): Promise<AssetResponseNCW>;
 
     /**
      * get NCW wallet setup status

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,17 @@ export interface AssetResponse {
     }[];
 }
 
+export interface AssetResponseNCW
+  extends Pick<
+    AssetResponse,
+    "id" | "total" | "pending" | "blockHash"
+  > {
+  frozen?: string;
+  reserved?: string;
+  staked?: string;
+  blockNumber?: string;
+}
+
 export interface UnfreezeTransactionResponse {
     success: boolean;
 }


### PR DESCRIPTION
…of Custodial APIs, extended existing type to accommodate

## Pull Request Description
I've created a patch to match the static typing to the API response of NCW Get Balance and Refresh Balance endpoints

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x ] Locally tested against Fireblocks API

## Checklist:

- [ x ] I have performed a self-review of my own code
- [ - ] I have made corresponding changes to the documentation
- [ - ] Any dependent changes have been merged and published in downstream modules
- [ - ] I have added corresponding labels to the PR
