### PR TITLE
Downgrade jsonwebtoken version to 8.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   "dependencies": {
     "@notabene/pii-sdk": "^1.17.0",
     "axios": "^1.6.0",
-    "jsonwebtoken": "9.0.0",
+    "jsonwebtoken": "8.5.1",
     "platform": "^1.3.6",
     "qs": "^6.11.0",
     "query-string": "^7.1.3",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.2",
+    "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^16.18.25",
     "@types/platform": "^1.3.4",
     "@types/qs": "^6.9.7",


### PR DESCRIPTION
## Pull Request Description

In PR #132 , the Snyk bot suggested to update the jsonwebtoken module from 8.5.1 to 9.0.0.
Merging it was a bad decision.

JWT 9.0.0 has bugs, notably, it doesn't work when it's used in a browser. See:
 - https://github.com/auth0/node-jsonwebtoken/issues/863
 - https://github.com/auth0/node-jsonwebtoken/issues/892
The proposed fixes are to either downgrade the module to 8.5.1 or not to use it at all, as it's not supposed to be used outside of a server.

The reason why JWT was updated in fireblocks SDK in the first place is nonsensical. This is to fix a security issue, linked in the PR: https://security.snyk.io/vuln/SNYK-JS-JSONWEBTOKEN-3180022

This security issue mentions the possibility to bypass the signature process when giving a null private key for example.
This is not a problem, as the only usage of that module in the fireblocks sdk is to sign data before calling an API: https://github.com/search?q=repo%3Afireblocks%2Ffireblocks-sdk-js%20jsonwebtoken&type=code

Should the signature be bypassed, the API call just won't work, nothing more. No security issue here.

Choosing to update JWT on the other hand, that prevents using the SDK in a browser, which has many interesting use cases.
When trying to integrate, an exception is raised at the first API call:
```
provider.ts:225 Uncaught (in promise) Error: Fireblocks SDK Error: Right-hand side of 'instanceof' is not an object
    at FireblocksWeb3Provider.createFireblocksError (provider.ts:225:17)
    at FireblocksWeb3Provider.populateAccounts (provider.ts:205:20)
```

No fix to this has been proposed by the JWT project. The only way to avoid it is to downgrade or use something else.

Therefore, I suggest rolling back this upgrade.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The bug was discovered when trying to use the code provided at https://developers.fireblocks.com/reference/evm-web3-provider
Downgrading the JWT package fixes the exception mentionned above.

- [X] Locally tested against Fireblocks API

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have added corresponding labels to the PR
