### PR TITLE
staking-sdk: add solana split support

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -161,7 +161,7 @@ import {
     ChainInfo,
     CheckTermsOfServiceResponseDto,
     DelegationSummaryDto,
-    DelegationSummaryDtoByVault,
+    DelegationSummaryDtoByVault, SplitRequestDto, SplitResponse,
     StakeRequestDto,
     StakeResponse,
     StakingChain,
@@ -313,6 +313,12 @@ export class FireblocksSDK {
      */
     public async executeStakingClaimRewards(chainDescriptor: StakingChain, body: WithdrawRequestDto): Promise<WithdrawResponse> {
         return await this.stakingApiClient.withdraw(chainDescriptor, body);
+    }
+    /**
+     * Execute staking split on a chain
+     */
+    public async executeStakingSplit(chainDescriptor: StakingChain, body: SplitRequestDto): Promise<SplitResponse> {
+        return await this.stakingApiClient.split(chainDescriptor, body);
     }
     /**
      * Get all staking positions, optionally filtered by chain

--- a/src/staking/staking-api-client.ts
+++ b/src/staking/staking-api-client.ts
@@ -2,7 +2,7 @@ import {
     ChainInfo,
     CheckTermsOfServiceResponseDto, ClaimRewardsRequestDto, ClaimRewardsResponse,
     DelegationSummaryDto,
-    DelegationSummaryDtoByVault,
+    DelegationSummaryDtoByVault, SplitRequestDto, SplitResponse,
     StakeRequestDto, StakeResponse,
     StakingChain,
     StakingPosition, StakingProvider,
@@ -60,6 +60,12 @@ export class StakingApiClient implements StakingSDK {
     ): Promise<ClaimRewardsResponse> {
         return await this.apiClient.issuePostRequest(
             `${STAKING_BASE_PATH}/chains/${chainDescriptor}/claimRewards`,
+            body,
+        );
+    }
+    public async split(chainDescriptor: StakingChain, body: SplitRequestDto): Promise<SplitResponse> {
+        return await this.apiClient.issuePostRequest(
+            `${STAKING_BASE_PATH}/chains/${chainDescriptor}/split`,
             body,
         );
     }

--- a/src/staking/staking-sdk.ts
+++ b/src/staking/staking-sdk.ts
@@ -2,7 +2,7 @@ import {
     ChainInfo,
     CheckTermsOfServiceResponseDto, ClaimRewardsRequestDto, ClaimRewardsResponse,
     DelegationSummaryDto,
-    DelegationSummaryDtoByVault,
+    DelegationSummaryDtoByVault, SplitRequestDto, SplitResponse,
     StakeRequestDto,
     StakeResponse,
     StakingChain,
@@ -54,6 +54,11 @@ export interface StakingSDK {
      * Execute staking claim rewards on a chain
      */
     claimRewards(chainDescriptor: StakingChain, body: ClaimRewardsRequestDto): Promise<ClaimRewardsResponse>;
+
+    /**
+     * Execute staking split on a chain
+     */
+    split(chainDescriptor: StakingChain, body: SplitRequestDto): Promise<SplitResponse>;
 
     /**
      * Get all staking positions, optionally filtered by chain

--- a/src/staking/types.ts
+++ b/src/staking/types.ts
@@ -230,6 +230,10 @@ export type WithdrawResponse = {};
 
 export type ClaimRewardsResponse = {};
 
+export type SplitResponse = {
+    id: string;
+};
+
 export interface StakeRequestDto {
     /**
      * The source vault account to stake from
@@ -311,6 +315,33 @@ export interface ClaimRewardsRequestDto {
      * id of position to withdraw rewards from
      */
     id: string;
+
+    /**
+     * Represents the fee for a transaction, which can be specified as a percentage value. Only one of fee/feeLevel is required
+     */
+    fee?: string;
+
+    /**
+     * Represents the fee level for a transaction, which can be set as slow, medium, or fast. Only one of fee/feeLevel is required
+     */
+    feeLevel?: string;
+
+    /**
+     * The note to associate with the transactions
+     */
+    txNote?: string;
+}
+
+export interface SplitRequestDto {
+    /**
+     * id of position to split
+     */
+    id: string;
+
+    /**
+     * Amount of tokens to split
+     */
+    amount: string;
 
     /**
      * Represents the fee for a transaction, which can be specified as a percentage value. Only one of fee/feeLevel is required


### PR DESCRIPTION
## Pull Request Description

This pull request introduces the SPLIT functionality in Staking. It allows users to split an existing stake account into two separate accounts, reallocating a portion of the funds from the original account into a newly created one.

Dependencies:
No new dependencies were added for this change.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
