### PR TITLE
Travel Rule - beneficiaryVASPdid is optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -387,8 +387,13 @@ export interface TransactionArguments {
 }
 
 export type OwnershipProof = {
-    type: string;
-    proof: string;
+    type?: string;
+    proof?: string;
+    attestation?: string;
+    address?: string;
+    wallet_provider?: string;
+    url?: string;
+    confirmed?: boolean;
 };
 
 export enum TravelRuleAddressTypeCode {
@@ -460,8 +465,19 @@ export interface TravelRule {
     beneficiaryRef?: string;
     originatorVASPdid: string;
     travelRuleBehavior?: boolean;
-    beneficiaryVASPdid: string;
+    beneficiaryVASPdid?: string;
     beneficiaryVASPname?: string;
+    originatorVASPname?: string;
+    beneficiaryVASPwebsite?: string;
+    encryptedMessage?: string;
+    protocol?: string;
+    skipBeneficiaryDataValidation?: boolean;
+    travelRuleBehaviorRef?: string;
+    originatorProof?: OwnershipProof;
+    beneficiaryProof?: OwnershipProof;
+    beneficiaryDid?: string;
+    originatorDid?: string;
+    isNonCustodial?: boolean;
     originator: TROriginator;
     beneficiary: TRBeneficiary;
     pii?: PII;


### PR DESCRIPTION
## Pull Request Description

Update TravelRule interface, beneficiaryVASPdid should be an optional add additional optional fields to the interface

Fixes (link to the issue here)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
