### PR TITLE
Add paginated endpoint to get balance on /internal_wallets/<wallet id>/assets

### DIFF
--- a/src/fireblocks-sdk.ts
+++ b/src/fireblocks-sdk.ts
@@ -158,6 +158,7 @@ import {
     ListBlockchainResponse,
     ListBlockchainsFilters,
     ListBlockchainsResponse,
+    PaginatedInternalWalletContainerResponse,
 } from "./types";
 import { AxiosProxyConfig, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import { PIIEncryption } from "./pii-client";
@@ -755,6 +756,16 @@ export class FireblocksSDK {
      */
     public async getInternalWallet(walletId: string): Promise<WalletContainerResponse<InternalWalletAsset>> {
         return await this.apiClient.issueGetRequest(`/v1/internal_wallets/${walletId}`);
+    }
+
+    /**
+     * Gets a paginated response of assets for a single internal wallet
+     * @param walletId The internal wallet ID
+     * @param pageSize Number of assets to return per page (default=50, max=200)
+     * @param pageCursor Cursor for pagination
+     */
+    public async getInternalWalletAssets(walletId: string, pageSize?: number, pageCursor?: string): Promise<PaginatedInternalWalletContainerResponse> {
+        return await this.apiClient.issueGetRequest(`/v1/internal_wallets/${walletId}/assets`, {pageSize, pageCursor});
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -240,6 +240,12 @@ export interface WalletContainerResponse<WalletAssetType> {
     customerRefId?: string;
 }
 
+export interface PaginatedInternalWalletContainerResponse{
+    total: number;
+    data: WalletContainerResponse<InternalWalletAsset>;
+    next: string | null;
+}
+
 export interface ExternalWalletAsset {
     id: string;
     status: string;


### PR DESCRIPTION
## Pull Request Description

feat: add get_internal_wallet_assets method for paginated asset retrieval

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Locally tested against Fireblocks API

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR