### PR TITLE
update Audit interface to include eventKey and userId field

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1780,7 +1780,9 @@ export interface Audit {
     createdAt?: string;
     subject?: string;
     event?: string;
+    eventKey?: string;
     user?: string;
+    userId?: string;
     email?: string;
     txId?: string;
     amount?: string;


### PR DESCRIPTION
## Pull Request Description

The current Audit interface in src/types.ts of the Fireblocks SDK is missing two crucial fields: userId and eventKey. However, these fields are present in the actual response payload returned by the getPaginatedAuditLogs method. This discrepancy causes type mismatches or loss of type safety when consuming audit log responses. This PR adds the missing userId and eventKey fields to the Audit interface to align the SDK typings with the actual API response and enable proper type-safe usage.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran build command and used the new custom SDK in my Express app. Works fine now and I do not see the compile-time error. I am using Typescript in the Express app.

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
