### PR TITLE
fix: wrong return type for drop transaction

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1435,8 +1435,9 @@ export interface PublicKeyInformation {
 }
 
 export interface DropTransactionResponse {
-    success: boolean;
-    transactions?: string[];
+    txStatus: TransactionStatus;
+    txId: string;
+    replacedTxHash: string;
 }
 
 export interface MaxSpendableAmountResponse {


### PR DESCRIPTION
## Pull Request Description

The return type of the dropTransaction method is wrong.
https://developers.fireblocks.com/reference/droptransaction


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [X] Locally tested against Fireblocks API

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
